### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/arfatef/d448eae2-8f6f-438d-91bf-a571859e342d/3e7813de-c4f3-4a89-9fb8-cfef004a48e5/_apis/work/boardbadge/10d5b034-0a38-417d-8536-f119e72e7aa2)](https://dev.azure.com/arfatef/d448eae2-8f6f-438d-91bf-a571859e342d/_boards/board/t/3e7813de-c4f3-4a89-9fb8-cfef004a48e5/Microsoft.RequirementCategory)
 # advent-of-code-2019
 Solutions for advent of code 2019
 [![Run on Repl.it](https://repl.it/badge/github/arfaoui47/advent-of-code-2019)](https://repl.it/github/arfaoui47/advent-of-code-2019)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/arfatef/d448eae2-8f6f-438d-91bf-a571859e342d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.